### PR TITLE
update html eex scope to .text.html.elixir

### DIFF
--- a/snippets/phoenix-elixir-snippets.cson
+++ b/snippets/phoenix-elixir-snippets.cson
@@ -80,7 +80,7 @@
     'body': 'IEx.pry'
   # the below ones are from phoenix-snippets including 'pry' above
   # https://github.com/phoenixframework-Brazil/phoenix-snippets.git
-'.text.elixir':
+'.text.html.elixir':
   'eex_render_block':
     'prefix': '='
     'body': '<%= $1 %>'


### PR DESCRIPTION
Hi, it seems that the scope for .html.eex files changed in Atom. 
It would be great if you merged this and put out a new version :)

Thanks